### PR TITLE
Add 'nix dev-shell' and 'nix print-dev-env' command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,5 +17,10 @@
     packages.nix = hydraJobs.build.x86_64-linux;
 
     defaultPackage = packages.nix;
+
+    devShell = import ./shell.nix {
+      nixpkgs = deps.nixpkgs;
+    };
+
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,8 @@
-{ useClang ? false }:
+{ useClang ? false
+, nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
+}:
 
-with import (builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz) {};
+with import nixpkgs { system = builtins.currentSystem or "x86_64-linux"; };
 
 with import ./release-common.nix { inherit pkgs; };
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1805,7 +1805,7 @@ void DerivationGoal::startBuilder()
             concatStringsSep(", ", parsedDrv->getRequiredSystemFeatures()),
             drvPath,
             settings.thisSystem,
-            concatStringsSep(", ", settings.systemFeatures));
+            concatStringsSep<StringSet>(", ", settings.systemFeatures));
 
     if (drv->isBuiltin())
         preloadNSS();

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -726,12 +726,7 @@ ValidPathInfo decodeValidPathInfo(std::istream & str, bool hashGiven)
 
 string showPaths(const PathSet & paths)
 {
-    string s;
-    for (auto & i : paths) {
-        if (s.size() != 0) s += ", ";
-        s += "'" + i + "'";
-    }
-    return s;
+    return concatStringsSep(", ", quoteStrings(paths));
 }
 
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -461,6 +461,17 @@ Path createTempDir(const Path & tmpRoot, const Path & prefix,
 }
 
 
+std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
+{
+    Path tmpl(getEnv("TMPDIR", "/tmp") + "/" + prefix + ".XXXXXX");
+    // Strictly speaking, this is UB, but who cares...
+    AutoCloseFD fd(mkstemp((char *) tmpl.c_str()));
+    if (!fd)
+        throw SysError("creating temporary file '%s'", tmpl);
+    return {std::move(fd), tmpl};
+}
+
+
 static Lazy<Path> getHome2([]() {
     Path homeDir = getEnv("HOME");
     if (homeDir.empty()) {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1167,28 +1167,6 @@ template StringSet tokenizeString(const string & s, const string & separators);
 template vector<string> tokenizeString(const string & s, const string & separators);
 
 
-string concatStringsSep(const string & sep, const Strings & ss)
-{
-    string s;
-    for (auto & i : ss) {
-        if (s.size() != 0) s += sep;
-        s += i;
-    }
-    return s;
-}
-
-
-string concatStringsSep(const string & sep, const StringSet & ss)
-{
-    string s;
-    for (auto & i : ss) {
-        if (s.size() != 0) s += sep;
-        s += i;
-    }
-    return s;
-}
-
-
 string chomp(const string & s)
 {
     size_t i = s.find_last_not_of(" \n\r\t");

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -334,8 +334,26 @@ template<class C> C tokenizeString(const string & s, const string & separators =
 
 /* Concatenate the given strings with a separator between the
    elements. */
-string concatStringsSep(const string & sep, const Strings & ss);
-string concatStringsSep(const string & sep, const StringSet & ss);
+template<class C>
+string concatStringsSep(const string & sep, const C & ss)
+{
+    string s;
+    for (auto & i : ss) {
+        if (s.size() != 0) s += sep;
+        s += i;
+    }
+    return s;
+}
+
+
+/* Add quotes around a collection of strings. */
+template<class C> Strings quoteStrings(const C & c)
+{
+    Strings res;
+    for (auto & s : c)
+        res.push_back("'" + s + "'");
+    return res;
+}
 
 
 /* Remove trailing whitespace from a string. */

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -118,10 +118,6 @@ void deletePath(const Path & path);
 
 void deletePath(const Path & path, unsigned long long & bytesFreed);
 
-/* Create a temporary directory. */
-Path createTempDir(const Path & tmpRoot = "", const Path & prefix = "nix",
-    bool includePid = true, bool useGlobalCounter = true, mode_t mode = 0755);
-
 /* Return $HOME or the user's home directory from /etc/passwd. */
 Path getHome();
 
@@ -197,6 +193,14 @@ public:
     explicit operator bool() const;
     int release();
 };
+
+
+/* Create a temporary directory. */
+Path createTempDir(const Path & tmpRoot = "", const Path & prefix = "nix",
+    bool includePid = true, bool useGlobalCounter = true, mode_t mode = 0755);
+
+/* Create a temporary file, returning a file handle and its path. */
+std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix = "nix");
 
 
 class Pipe

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -88,6 +88,11 @@ struct SourceExprCommand : virtual Args, StoreCommand, MixEvalArgs
     std::shared_ptr<Installable> parseInstallable(
         ref<Store> store, const std::string & installable);
 
+    virtual Strings getDefaultFlakeAttrPaths()
+    {
+        return {"defaultPackage"};
+    }
+
 private:
 
     std::shared_ptr<EvalState> evalState;

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -125,6 +125,7 @@ struct Common : InstallableCommand
         "BASHOPTS",
         "EUID",
         "NIX_BUILD_TOP",
+        "NIX_ENFORCE_PURITY",
         "PPID",
         "PWD",
         "SHELLOPTS",
@@ -155,6 +156,11 @@ struct Common : InstallableCommand
         out << "export NIX_BUILD_TOP=\"$(mktemp -d --tmpdir nix-shell.XXXXXX)\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
+    }
+
+    Strings getDefaultFlakeAttrPaths() override
+    {
+        return {"devShell", "defaultPackage"};
     }
 };
 

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -1,0 +1,276 @@
+#include "eval.hh"
+#include "command.hh"
+#include "common-args.hh"
+#include "shared.hh"
+#include "store-api.hh"
+#include "derivations.hh"
+#include "affinity.hh"
+#include "progress-bar.hh"
+
+using namespace nix;
+
+struct BuildEnvironment
+{
+    // FIXME: figure out which vars should be exported.
+    std::map<std::string, std::string> env;
+    std::map<std::string, std::string> functions;
+};
+
+BuildEnvironment readEnvironment(const Path & path)
+{
+    BuildEnvironment res;
+
+    auto lines = tokenizeString<Strings>(readFile(path), "\n");
+
+    auto getLine =
+        [&]() {
+            if (lines.empty())
+                throw Error("shell environment '%s' ends unexpectedly", path);
+            auto line = lines.front();
+            lines.pop_front();
+            return line;
+        };
+
+    while (!lines.empty()) {
+        auto line = getLine();
+
+        auto eq = line.find('=');
+        if (eq != std::string::npos) {
+            std::string name(line, 0, eq);
+            std::string value(line, eq + 1);
+            // FIXME: parse arrays
+            res.env.insert({name, value});
+        }
+
+        else if (hasSuffix(line, " () ")) {
+            std::string name(line, 0, line.size() - 4);
+            // FIXME: validate name
+            auto l = getLine();
+            if (l != "{ ") throw Error("shell environment '%s' has unexpected line '%s'", path, l);
+            std::string body;
+            while ((l = getLine()) != "}") {
+                body += l;
+                body += '\n';
+            }
+            res.functions.insert({name, body});
+        }
+
+        else throw Error("shell environment '%s' has unexpected line '%s'", path, line);
+    }
+
+    return res;
+}
+
+/* Given an existing derivation, return the shell environment as
+   initialised by stdenv's setup script. We do this by building a
+   modified derivation with the same dependencies and nearly the same
+   initial environment variables, that just writes the resulting
+   environment to a file and exits. */
+BuildEnvironment getDerivationEnvironment(ref<Store> store, Derivation drv)
+{
+    auto builder = baseNameOf(drv.builder);
+    if (builder != "bash")
+        throw Error("'nix shell' only works on derivations that use 'bash' as their builder");
+
+    drv.args = {"-c", "set -e; if [[ -n $stdenv ]]; then source $stdenv/setup; fi; set > $out"};
+
+    /* Remove derivation checks. */
+    drv.env.erase("allowedReferences");
+    drv.env.erase("allowedRequisites");
+    drv.env.erase("disallowedReferences");
+    drv.env.erase("disallowedRequisites");
+
+    // FIXME: handle structured attrs
+
+    /* Rehash and write the derivation. FIXME: would be nice to use
+       'buildDerivation', but that's privileged. */
+    auto drvName = drv.env["name"] + "-env";
+    for (auto & output : drv.outputs)
+        drv.env.erase(output.first);
+    drv.env["out"] = "";
+    drv.env["outputs"] = "out";
+    drv.outputs["out"] = DerivationOutput("", "", "");
+    Hash h = hashDerivationModulo(*store, drv);
+    Path shellOutPath = store->makeOutputPath("out", h, drvName);
+    drv.outputs["out"].path = shellOutPath;
+    drv.env["out"] = shellOutPath;
+    Path shellDrvPath2 = writeDerivation(store, drv, drvName);
+
+    /* Build the derivation. */
+    store->buildPaths({shellDrvPath2});
+
+    assert(store->isValidPath(shellOutPath));
+
+    return readEnvironment(shellOutPath);
+}
+
+struct Common : InstallableCommand
+{
+    /*
+    std::set<string> keepVars{
+        "DISPLAY",
+        "HOME",
+        "IN_NIX_SHELL",
+        "LOGNAME",
+        "NIX_BUILD_SHELL",
+        "PAGER",
+        "PATH",
+        "TERM",
+        "TZ",
+        "USER",
+    };
+    */
+
+    std::set<string> ignoreVars{
+        "BASHOPTS",
+        "EUID",
+        "NIX_BUILD_TOP",
+        "PPID",
+        "PWD",
+        "SHELLOPTS",
+        "SHLVL",
+        "TEMP",
+        "TEMPDIR",
+        "TMP",
+        "TMPDIR",
+        "UID",
+    };
+
+    void makeRcScript(const BuildEnvironment & buildEnvironment, std::ostream & out)
+    {
+        for (auto & i : buildEnvironment.env) {
+            // FIXME: shellEscape
+            // FIXME: figure out what to export
+            // FIXME: handle arrays
+            if (!ignoreVars.count(i.first) && !hasPrefix(i.first, "BASH_"))
+                out << fmt("export %s=%s\n", i.first, i.second);
+        }
+
+        for (auto & i : buildEnvironment.functions) {
+            out << fmt("%s () {\n%s\n}\n", i.first, i.second);
+        }
+
+        // FIXME: set outputs
+
+        out << "export NIX_BUILD_TOP=\"$(mktemp -d --tmpdir nix-shell.XXXXXX)\"\n";
+        for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
+            out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
+    }
+};
+
+std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix = "nix")
+{
+    Path tmpl(getEnv("TMPDIR", "/tmp") + "/" + prefix + ".XXXXXX");
+    // Strictly speaking, this is UB, but who cares...
+    AutoCloseFD fd(mkstemp((char *) tmpl.c_str()));
+    if (!fd)
+        throw SysError("creating temporary file '%s'", tmpl);
+    return {std::move(fd), tmpl};
+}
+
+struct CmdDevShell : Common
+{
+
+    std::string name() override
+    {
+        return "dev-shell";
+    }
+
+    std::string description() override
+    {
+        return "run a bash shell that provides the build environment of a derivation";
+    }
+
+    Examples examples() override
+    {
+        return {
+            Example{
+                "To get the build environment of GNU hello:",
+                "nix dev-shell nixpkgs:hello"
+            },
+            Example{
+                "To get the build environment of the default package of flake in the current directory:",
+                "nix dev-shell"
+            },
+        };
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto drvs = toDerivations(store, {installable});
+
+        if (drvs.size() != 1)
+            throw Error("'%s' needs to evaluate to a single derivation, but it evaluated to %d derivations",
+                installable->what(), drvs.size());
+
+        auto & drvPath = *drvs.begin();
+
+        auto buildEnvironment = getDerivationEnvironment(store, store->derivationFromPath(drvPath));
+
+        auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
+
+        std::ostringstream ss;
+        makeRcScript(buildEnvironment, ss);
+
+        ss << fmt("rm -f '%s'\n", rcFilePath);
+
+        writeFull(rcFileFd.get(), ss.str());
+
+        stopProgressBar();
+
+        auto shell = getEnv("SHELL", "bash");
+
+        auto args = Strings{baseNameOf(shell), "--rcfile", rcFilePath};
+
+        restoreAffinity();
+        restoreSignals();
+
+        execvp(shell.c_str(), stringsToCharPtrs(args).data());
+
+        throw SysError("executing shell '%s'", shell);
+    }
+};
+
+struct CmdPrintDevEnv : Common
+{
+
+    std::string name() override
+    {
+        return "print-dev-env";
+    }
+
+    std::string description() override
+    {
+        return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
+    }
+
+    Examples examples() override
+    {
+        return {
+            Example{
+                "To apply the build environment of GNU hello to the current shell:",
+                ". <(nix print-dev-env nixpkgs:hello)"
+            },
+        };
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto drvs = toDerivations(store, {installable});
+
+        if (drvs.size() != 1)
+            throw Error("'%s' needs to evaluate to a single derivation, but it evaluated to %d derivations",
+                installable->what(), drvs.size());
+
+        auto & drvPath = *drvs.begin();
+
+        auto buildEnvironment = getDerivationEnvironment(store, store->derivationFromPath(drvPath));
+
+        stopProgressBar();
+
+        makeRcScript(buildEnvironment, std::cout);
+    }
+};
+
+static RegisterCommand r1(make_ref<CmdPrintDevEnv>());
+static RegisterCommand r2(make_ref<CmdDevShell>());

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -156,6 +156,8 @@ struct Common : InstallableCommand
         out << "export NIX_BUILD_TOP=\"$(mktemp -d --tmpdir nix-shell.XXXXXX)\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
+
+        out << "eval \"$shellHook\"\n";
     }
 
     Strings getDefaultFlakeAttrPaths() override

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -166,16 +166,6 @@ struct Common : InstallableCommand
     }
 };
 
-std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix = "nix")
-{
-    Path tmpl(getEnv("TMPDIR", "/tmp") + "/" + prefix + ".XXXXXX");
-    // Strictly speaking, this is UB, but who cares...
-    AutoCloseFD fd(mkstemp((char *) tmpl.c_str()));
-    if (!fd)
-        throw SysError("creating temporary file '%s'", tmpl);
-    return {std::move(fd), tmpl};
-}
-
 struct CmdDevShell : Common
 {
 


### PR DESCRIPTION
`nix dev-shell` is intended to replace `nix-shell`. It supports flakes, e.g.
```
$ nix dev-shell nixpkgs:hello
```
starts a bash shell providing an environment for building 'hello'.

Like Lorri (and unlike nix-shell), it computes the build environment by building a modified top-level derivation that writes the environment after running `$stdenv/setup` to `$out` and exits. This provides some caching, so it's faster than nix-shell in some cases (especially for packages with lots of dependencies, where the setup script takes a long time).

There also is a command `nix print-dev-env` that prints out shell code for setting up the build environment in an existing shell, e.g.
```
$ . <(nix print-dev-env nixpkgs:hello)
```

Issue #21.