### PR TITLE
Make flakes work with 'nix build --store ...'

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -259,7 +259,7 @@ static void prim_fetchGit(EvalState & state, const Pos & pos, Value * * args, Va
     v.attrs->sort();
 
     if (state.allowedPaths)
-        state.allowedPaths->insert(gitInfo.storePath);
+        state.allowedPaths->insert(state.store->toRealPath(gitInfo.storePath));
 }
 
 static RegisterPrimOp r("fetchGit", 1, prim_fetchGit);

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -214,7 +214,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
     v.attrs->sort();
 
     if (state.allowedPaths)
-        state.allowedPaths->insert(hgInfo.storePath);
+        state.allowedPaths->insert(state.store->toRealPath(hgInfo.storePath));
 }
 
 static RegisterPrimOp r("fetchMercurial", 1, prim_fetchMercurial);

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -804,6 +804,7 @@ CachedDownloadResult Downloader::downloadCached(ref<Store> store, const string &
         expectedStorePath = store->makeFixedOutputPath(unpack, expectedHash, name);
         if (store->isValidPath(expectedStorePath)) {
             CachedDownloadResult result;
+            result.storePath = expectedStorePath;
             result.path = store->toRealPath(expectedStorePath);
             return result;
         }
@@ -912,6 +913,7 @@ CachedDownloadResult Downloader::downloadCached(ref<Store> store, const string &
             url, expectedHash.to_string(), gotHash.to_string());
     }
 
+    result.storePath = storePath;
     result.path = store->toRealPath(storePath);
     return result;
 }

--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -43,6 +43,9 @@ struct DownloadResult
 
 struct CachedDownloadResult
 {
+    // Note: 'storePath' may be different from 'path' when using a
+    // chroot store.
+    Path storePath;
     Path path;
     std::optional<std::string> etag;
 };


### PR DESCRIPTION
It was getting confused between logical and real store paths.

Also, make `fetchGit` and `fetchMercurial` update `allowedPaths` properly.

(Maybe the evaluator, rather than the caller of the evaluator, should apply `toRealPath()`, but that's a bigger change.)